### PR TITLE
Fix Telegram files path to use mounted /data volume

### DIFF
--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -14,7 +14,7 @@ export interface TelegramBotConfig {
     logger?: Logger;
 }
 
-const TELEGRAM_FILES_DIR = resolve('./data/telegram-files');
+const TELEGRAM_FILES_DIR = resolve('/data/telegram-files');
 
 export class TelegramBot {
     private bot: Bot;


### PR DESCRIPTION
TELEGRAM_FILES_DIR was resolving to /app/data/telegram-files (relative
to WORKDIR) instead of the mounted /data volume, causing downloaded
files to be written to ephemeral container storage where Claude Code
couldn't reliably access them.

https://claude.ai/code/session_01EoE7hgHfaGf94wEQoScjFZ