### PR TITLE
fix: prevent stale execution_mode after cron job edit

### DIFF
--- a/src/cron/scheduler.ts
+++ b/src/cron/scheduler.ts
@@ -72,7 +72,16 @@ export class CronScheduler {
                 timezone: job.timezone,
                 catch: true,
                 unref: true // Don't hold the process open
-            }, () => this.executeJob(job));
+            }, async () => {
+                // Read fresh from DB so edits (e.g. execution_mode change) take effect
+                // without needing a reschedule. Mirrors the behaviour of triggerJob().
+                const freshJob = this.config.db.getCronJob(job.name);
+                if (freshJob) {
+                    await this.executeJob(freshJob);
+                } else {
+                    this.logger.warn({ name: job.name }, 'Scheduled job not found in DB, skipping execution');
+                }
+            });
 
             this.jobs.set(job.name, cron);
             this.logger.info({ event: 'cron_scheduled', name: job.name, schedule: job.schedule, timezone: job.timezone }, 'Scheduled job');
@@ -188,6 +197,7 @@ export class CronScheduler {
     }
 
     private async executeJob(job: CronJobRow): Promise<void> {
+        this.logger.info({ name: job.name, execution_mode: job.execution_mode }, 'Dispatching cron job');
         if (job.execution_mode === 'api') {
             await this.executeJobApi(job);
         } else {


### PR DESCRIPTION
Fixes #12

The scheduled Cron callback in `addJob()` captured the job object in a closure, so any edit to `execution_mode` after scheduling could persist until the next reschedule cycle. Reads fresh from DB on each scheduled trigger instead, matching the behaviour of `triggerJob()`. Also adds an `execution_mode` log line in `executeJob()` for observability.

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/al-how/claude-conductor/actions/runs/22248467015