### PR TITLE
fix: wire queue.timeout_seconds config to fix long task timeouts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-conductor",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Docker container wrapping Claude Code CLI with scheduling, messaging, and webhook capabilities",
   "type": "module",
   "main": "dist/main.js",

--- a/src/dispatcher/index.ts
+++ b/src/dispatcher/index.ts
@@ -12,9 +12,11 @@ export class Dispatcher {
     private queue: Task[] = [];
     private processing: boolean = false;
     private logger?: Logger;
+    private defaultTimeoutMs: number;
 
-    constructor(_maxConcurrent: number = 1, logger?: Logger) {
+    constructor(_maxConcurrent: number = 1, logger?: Logger, defaultTimeoutMs: number = 300_000) {
         this.logger = logger;
+        this.defaultTimeoutMs = defaultTimeoutMs;
     }
 
     public enqueue(task: Task): void {
@@ -45,7 +47,10 @@ export class Dispatcher {
                         invokeOptions.logger = this.logger;
                     }
 
-                    const result = await invokeClaude(invokeOptions);
+                    const result = await invokeClaude({
+                        ...invokeOptions,
+                        timeout: invokeOptions.timeout ?? this.defaultTimeoutMs,
+                    });
 
                     const duration = Math.round((Date.now() - startTime) / 1000);
                     this.logger?.info({ event: 'session_complete', taskId: task.id, source: task.source, duration, numTurns: result.numTurns, exitCode: result.exitCode }, 'Session complete');

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,7 +54,7 @@ export async function main() {
     }
 
     // Initialize Dispatcher
-    const dispatcher = new Dispatcher(config.queue.max_concurrent, logger);
+    const dispatcher = new Dispatcher(config.queue.max_concurrent, logger, config.queue.timeout_seconds * 1000);
 
     // Initialize Telegram Bot
     let bot: TelegramBot | undefined;

--- a/tests/dispatcher/dispatcher.test.ts
+++ b/tests/dispatcher/dispatcher.test.ts
@@ -66,6 +66,55 @@ describe('Dispatcher', () => {
         expect(callOrder).toEqual(['first', 'second']);
     });
 
+    it('should apply defaultTimeoutMs when task has no timeout', async () => {
+        const invokeSpy = vi.spyOn(ClaudeInvoke, 'invokeClaude').mockResolvedValue({
+            exitCode: 0,
+            stdout: '{}',
+            stderr: '',
+            timedOut: false
+        });
+
+        const customTimeoutDispatcher = new Dispatcher(1, undefined, 1800_000);
+
+        await new Promise<void>((resolve) => {
+            customTimeoutDispatcher.enqueue({
+                id: 'timeout-test',
+                source: 'telegram',
+                prompt: 'test',
+                onComplete: async () => resolve()
+            });
+        });
+
+        expect(invokeSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ timeout: 1800_000 })
+        );
+    });
+
+    it('should respect task-level timeout over default', async () => {
+        const invokeSpy = vi.spyOn(ClaudeInvoke, 'invokeClaude').mockResolvedValue({
+            exitCode: 0,
+            stdout: '{}',
+            stderr: '',
+            timedOut: false
+        });
+
+        const customTimeoutDispatcher = new Dispatcher(1, undefined, 1800_000);
+
+        await new Promise<void>((resolve) => {
+            customTimeoutDispatcher.enqueue({
+                id: 'task-timeout-test',
+                source: 'telegram',
+                prompt: 'test',
+                timeout: 60_000,
+                onComplete: async () => resolve()
+            });
+        });
+
+        expect(invokeSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ timeout: 60_000 })
+        );
+    });
+
     it('should handle errors gracefully', async () => {
         vi.spyOn(ClaudeInvoke, 'invokeClaude').mockRejectedValue(new Error('Spawn failed'));
 


### PR DESCRIPTION
The `queue.timeout_seconds` setting was defined in config schema (default 300s, max 3600s) but never passed to `invokeClaude`. Tasks always timed out at the hardcoded 5-minute default regardless of config.

The Dispatcher now accepts a `defaultTimeoutMs` constructor parameter and applies it when tasks don't specify their own timeout.

Fixes #20

Generated with [Claude Code](https://claude.ai/code)