### PR TITLE
feat: persist full cron execution logs for Claude introspection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-conductor",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Docker container wrapping Claude Code CLI with scheduling, messaging, and webhook capabilities",
   "type": "module",
   "main": "dist/main.js",

--- a/src/claude/execution-log.ts
+++ b/src/claude/execution-log.ts
@@ -1,0 +1,139 @@
+import { join } from 'node:path';
+import { mkdir, writeFile, readdir, unlink } from 'node:fs/promises';
+import type { StreamEvent } from './invoke.js';
+
+const MAX_PROMPT_LENGTH = 2000;
+const MAX_RESULT_LENGTH = 3000;
+const MAX_LOGS_PER_JOB = 10;
+
+export class ExecutionLogCollector {
+    private events: StreamEvent[] = [];
+
+    public collect = (event: StreamEvent): void => {
+        this.events.push(event);
+    };
+
+    public getEvents(): StreamEvent[] {
+        return this.events;
+    }
+}
+
+export interface ExecutionLogMeta {
+    jobName: string;
+    prompt: string;
+    startedAt: string;
+    finishedAt: string;
+    exitCode: number;
+}
+
+export function formatExecutionLog(events: StreamEvent[], meta: ExecutionLogMeta): string {
+    const lines: string[] = [];
+
+    // Header
+    lines.push(`# Execution Log: ${meta.jobName}`);
+    lines.push('');
+    lines.push(`- **Started:** ${meta.startedAt}`);
+    lines.push(`- **Finished:** ${meta.finishedAt}`);
+    lines.push(`- **Exit code:** ${meta.exitCode}`);
+
+    // Extract model from system_init event
+    const initEvent = events.find(e => e.type === 'system_init');
+    if (initEvent?.data.model) {
+        lines.push(`- **Model:** ${initEvent.data.model}`);
+    }
+
+    // Prompt
+    lines.push('');
+    lines.push('## Prompt');
+    lines.push('');
+    const promptText = meta.prompt.length > MAX_PROMPT_LENGTH
+        ? meta.prompt.slice(0, MAX_PROMPT_LENGTH) + '\n\n(truncated)'
+        : meta.prompt;
+    lines.push(promptText);
+
+    // Execution timeline
+    lines.push('');
+    lines.push('## Execution Timeline');
+    lines.push('');
+
+    for (const event of events) {
+        switch (event.type) {
+            case 'tool_use': {
+                const tool = event.data.tool as string;
+                const arg = event.data.arg as string | undefined;
+                lines.push(`### Tool: ${tool}`);
+                if (arg) {
+                    lines.push(`> ${arg}`);
+                }
+                lines.push('');
+                break;
+            }
+            case 'tool_result': {
+                const content = event.data.content as string;
+                const resultLines = event.data.lines as number;
+                const truncated = content.length > MAX_RESULT_LENGTH
+                    ? content.slice(0, MAX_RESULT_LENGTH) + '\n\n(truncated)'
+                    : content;
+                lines.push(`**Result** (${resultLines} lines):`);
+                lines.push(truncated);
+                lines.push('');
+                break;
+            }
+            case 'assistant_text': {
+                const text = event.data.text as string;
+                lines.push(text);
+                lines.push('');
+                break;
+            }
+            case 'result': {
+                const text = event.data.text as string | undefined;
+                if (text) {
+                    lines.push('## Final Output');
+                    lines.push('');
+                    lines.push(text);
+                    lines.push('');
+                }
+                break;
+            }
+            // system_init and error are not rendered in the timeline
+        }
+    }
+
+    return lines.join('\n');
+}
+
+export async function writeExecutionLog(
+    vaultPath: string,
+    jobName: string,
+    content: string,
+    startedAt: string,
+): Promise<string> {
+    const logDir = join(vaultPath, 'agent-files', 'logs', jobName);
+    await mkdir(logDir, { recursive: true });
+
+    const date = new Date(startedAt);
+    const pad = (n: number) => String(n).padStart(2, '0');
+    const filename = `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}_${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}.md`;
+    const logPath = join(logDir, filename);
+
+    await writeFile(logPath, content, 'utf-8');
+    return logPath;
+}
+
+export async function pruneOldLogs(vaultPath: string, jobName: string): Promise<void> {
+    const logDir = join(vaultPath, 'agent-files', 'logs', jobName);
+
+    let files: string[];
+    try {
+        files = (await readdir(logDir)).filter(f => f.endsWith('.md')).sort();
+    } catch {
+        return; // Directory doesn't exist yet
+    }
+
+    if (files.length <= MAX_LOGS_PER_JOB) return;
+
+    const toDelete = files.slice(0, files.length - MAX_LOGS_PER_JOB);
+    for (const file of toDelete) {
+        await unlink(join(logDir, file));
+    }
+}

--- a/src/claude/invoke.ts
+++ b/src/claude/invoke.ts
@@ -3,6 +3,12 @@ import { createInterface } from 'node:readline';
 import { existsSync } from 'node:fs';
 import type { Logger } from 'pino';
 
+export interface StreamEvent {
+    timestamp: string;
+    type: 'system_init' | 'tool_use' | 'tool_result' | 'assistant_text' | 'result' | 'error';
+    data: Record<string, unknown>;
+}
+
 export interface ClaudeInvokeOptions {
     prompt: string;
     workingDir?: string;
@@ -20,6 +26,7 @@ export interface ClaudeInvokeOptions {
     timeout?: number;
     logger?: Logger;
     providerEnv?: Record<string, string>;
+    onStreamEvent?: (event: StreamEvent) => void;
 }
 
 export interface ClaudeResult {
@@ -111,6 +118,7 @@ export async function invokeClaude(options: ClaudeInvokeOptions): Promise<Claude
     logger?.debug({ args, workingDir }, 'Invoking Claude Code');
 
     const effectiveFormat = options.outputFormat ?? 'stream-json';
+    const { onStreamEvent } = options;
 
     return new Promise((resolve) => {
         let stderr = '';
@@ -160,13 +168,26 @@ export async function invokeClaude(options: ClaudeInvokeOptions): Promise<Claude
                 // Debug: log all event types for format diagnosis
                 logger?.debug({ eventType, keys: Object.keys(parsed) }, 'Stream event received');
 
+                // Emit system_init event
+                if (eventType === 'system') {
+                    onStreamEvent?.({
+                        timestamp: new Date().toISOString(),
+                        type: 'system_init',
+                        data: {
+                            model: parsed.model,
+                            tools: parsed.tools,
+                            sessionId: parsed.session_id,
+                        }
+                    });
+                }
+
                 // Handle assistant messages — content array is at parsed.message.content
                 if (eventType === 'assistant') {
                     const message = parsed.message as Record<string, unknown> | undefined;
                     const content = message?.content;
                     if (Array.isArray(content)) {
                         for (const block of content) {
-                            handleContentEvent(block as Record<string, unknown>, logger);
+                            handleContentEvent(block as Record<string, unknown>, logger, onStreamEvent);
                         }
                     }
                 }
@@ -187,6 +208,11 @@ export async function invokeClaude(options: ClaudeInvokeOptions): Promise<Claude
                                     { event: 'tool_result', toolUseId: block.tool_use_id, lines, preview },
                                     `Tool result: ${lines} lines`
                                 );
+                                onStreamEvent?.({
+                                    timestamp: new Date().toISOString(),
+                                    type: 'tool_result',
+                                    data: { content: resultContent, lines, toolUseId: block.tool_use_id }
+                                });
                             }
                         }
                     }
@@ -201,6 +227,11 @@ export async function invokeClaude(options: ClaudeInvokeOptions): Promise<Claude
                 if (eventType === 'result') {
                     resultJson = parsed;
                     numTurns = parsed.num_turns as number | undefined;
+                    onStreamEvent?.({
+                        timestamp: new Date().toISOString(),
+                        type: 'result',
+                        data: { text: parsed.text ?? parsed.result, subtype: parsed.subtype, numTurns: parsed.num_turns }
+                    });
                 }
             });
         } else {
@@ -248,12 +279,17 @@ export async function invokeClaude(options: ClaudeInvokeOptions): Promise<Claude
     });
 }
 
-function handleContentEvent(block: Record<string, unknown>, logger?: Logger): void {
+function handleContentEvent(block: Record<string, unknown>, logger?: Logger, onStreamEvent?: (event: StreamEvent) => void): void {
     if (block.type === 'tool_use') {
         const toolName = block.name as string || 'unknown';
         const input = (block.input as Record<string, unknown>) || {};
         const arg = extractToolArg(toolName, input);
         logger?.info({ event: 'tool_use', tool: toolName, arg }, `Tool: ${toolName}`);
+        onStreamEvent?.({
+            timestamp: new Date().toISOString(),
+            type: 'tool_use',
+            data: { tool: toolName, arg, input }
+        });
     }
     if (block.type === 'text' && block.text) {
         const preview = block.text as string;
@@ -261,6 +297,11 @@ function handleContentEvent(block: Record<string, unknown>, logger?: Logger): vo
             { event: 'assistant_text', preview },
             'Assistant response'
         );
+        onStreamEvent?.({
+            timestamp: new Date().toISOString(),
+            type: 'assistant_text',
+            data: { text: preview }
+        });
     }
 }
 

--- a/src/cron/scheduler.ts
+++ b/src/cron/scheduler.ts
@@ -7,6 +7,7 @@ import type { DatabaseManager, CronJobRow } from '../db/index.js';
 import { extractResponseText } from '../claude/invoke.js';
 import { invokeApi } from '../claude/invoke-api.js';
 import { resolveModel } from '../claude/models.js';
+import { ExecutionLogCollector, formatExecutionLog, writeExecutionLog, pruneOldLogs } from '../claude/execution-log.js';
 
 export interface ApiConfig {
     anthropicApiKey: string;
@@ -287,6 +288,8 @@ export class CronScheduler {
         const enrichedPrompt = job.prompt + historyContext;
         const resolved = resolveModel(job.model ?? this.config.globalModel ?? undefined);
 
+        const collector = new ExecutionLogCollector();
+
         this.config.dispatcher.enqueue({
             id: `cron-${job.name}-${Date.now()}`,
             source: 'cron',
@@ -299,6 +302,7 @@ export class CronScheduler {
             model: resolved?.model,
             providerEnv: resolved?.provider === 'ollama' ? this.getOllamaEnv() : undefined,
             outputFormat: 'stream-json',
+            onStreamEvent: collector.collect,
             onComplete: async (result) => {
                 const responseText = extractResponseText(result);
                 const finishedAt = new Date().toISOString();
@@ -314,6 +318,22 @@ export class CronScheduler {
                     response_preview: responseText,
                     error: result.stderr
                 });
+
+                // Write execution log file
+                try {
+                    const logContent = formatExecutionLog(collector.getEvents(), {
+                        jobName: job.name,
+                        prompt: enrichedPrompt,
+                        startedAt: startTime,
+                        finishedAt,
+                        exitCode: result.exitCode,
+                    });
+                    const logPath = await writeExecutionLog(this.config.vaultPath, job.name, logContent, startTime);
+                    this.logger.debug({ jobName: job.name, logPath }, 'Execution log written');
+                    await pruneOldLogs(this.config.vaultPath, job.name);
+                } catch (logErr) {
+                    this.logger.warn({ err: logErr, jobName: job.name }, 'Failed to write execution log');
+                }
 
                 // Save to history for dedup on next run
                 if (result.exitCode === 0 && responseText.trim()) {


### PR DESCRIPTION
## Summary

- Add `onStreamEvent` callback to `ClaudeInvokeOptions` that emits structured `StreamEvent` objects at each parse point (system init, tool use, tool result, assistant text, final result)
- New `ExecutionLogCollector` class + markdown formatter + file writer in `src/claude/execution-log.ts`
- Wire up collector in `executeJobCli()` — logs written to `agent-files/logs/{jobName}/{timestamp}.md` with auto-pruning to 10 files per job

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — all 236 tests pass
- [ ] Trigger a cron job via `POST /api/cron/{name}/trigger` and verify log file created at `/vault/agent-files/logs/{jobName}/`
- [ ] Verify log contains tool usage timeline with args and results
- [ ] Verify old logs pruned when count exceeds 10
- [ ] From a Claude session, verify `Glob("agent-files/logs/**/*.md")` finds logs

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)