### PR TITLE
feat: add telegram.timeout_seconds config to fix long-task timeouts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-conductor",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Docker container wrapping Claude Code CLI with scheduling, messaging, and webhook capabilities",
   "type": "module",
   "main": "dist/main.js",

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -5,6 +5,7 @@ const TelegramConfigSchema = z.object({
     allowed_users: z.array(z.number().int().positive()).min(1, 'At least one allowed user required'),
     streaming_enabled: z.boolean().default(true),
     show_tool_events: z.boolean().default(true),
+    timeout_seconds: z.number().int().min(30).max(86400).optional(),
 });
 
 export const CronJobSchema = z.object({

--- a/src/main.ts
+++ b/src/main.ts
@@ -96,7 +96,8 @@ export async function main() {
             openRouterConfig: config.openrouter,
             ollamaConfig: config.ollama,
             streamingEnabled: config.telegram.streaming_enabled,
-            showToolEvents: config.telegram.show_tool_events
+            showToolEvents: config.telegram.show_tool_events,
+            timeoutSeconds: config.telegram.timeout_seconds
         });
         // bot.start() begins long-polling and only resolves on stop() — don't await it
         bot.start().catch(err => logger.error({ err }, 'Telegram Bot polling error'));

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -23,6 +23,7 @@ export interface TelegramBotConfig {
     ollamaConfig?: OllamaConfig;
     streamingEnabled?: boolean;
     showToolEvents?: boolean;
+    timeoutSeconds?: number;
 }
 
 const TELEGRAM_FILES_DIR = resolve(process.env.TELEGRAM_FILES_DIR || '/data/telegram-files');
@@ -50,6 +51,7 @@ export class TelegramBot {
     private ollamaConfig: OllamaConfig | undefined;
     private streamingEnabled: boolean;
     private showToolEvents: boolean;
+    private timeoutSeconds: number | undefined;
     private pendingLocations = new Map<number, string>();
 
     constructor(config: TelegramBotConfig) {
@@ -64,6 +66,7 @@ export class TelegramBot {
         this.ollamaConfig = config.ollamaConfig;
         this.streamingEnabled = config.streamingEnabled ?? true;
         this.showToolEvents = config.showToolEvents ?? true;
+        this.timeoutSeconds = config.timeoutSeconds;
 
         if (!config.token) {
             this.logger?.error('Telegram bot token is missing in config');
@@ -491,6 +494,7 @@ export class TelegramBot {
             dangerouslySkipPermissions: true,
             includePartialMessages: this.streamingEnabled,
             ...(hasSession ? { continue: true } : {}),
+            ...(this.timeoutSeconds !== undefined ? { timeout: this.timeoutSeconds * 1000 } : {}),
             model,
             providerEnv,
             onStreamEvent,


### PR DESCRIPTION
Fixes #27 — the global `queue.timeout_seconds` (default 5 min) was the only knob, making it impossible to allow long interactive Telegram sessions without raising the ceiling for cron jobs.

Adds `telegram.timeout_seconds` as an optional per-source override (30–86400 seconds). When set, Telegram tasks use it instead of the global queue timeout; cron and webhook defaults are unaffected.

Generated with [Claude Code](https://claude.ai/code)